### PR TITLE
Remove timeouts and instead activate grammars on text editor at new grammar creation.

### DIFF
--- a/lib/semanticolor.js
+++ b/lib/semanticolor.js
@@ -316,6 +316,11 @@ let Semanticolor = {
 
 		atom.grammars.onDidAddGrammar(function(grammar) {
 			createGrammar(grammar);
+
+			// Activate grammar on existing text editors with matching grammar
+			atom.workspace.getTextEditors()
+				.filter(editor => editor.getGrammar().name == grammar.name)
+				.map(enable);
 		});
 
 		function createGrammar(grammar) {
@@ -363,21 +368,6 @@ let Semanticolor = {
 
 		this.disposables.add(atom.workspace.observeTextEditors(enable));
 
-		setTimeout(enableEditors, 1000);
-
-		function enableEditors() {
-			let editors = atom.workspace.getTextEditors();
-			let enabled = 0;
-			for (let i = 0; i < editors.length; i++) {
-				if (enable(editors[i])) {
-					enabled++;
-				}
-			}
-			if (enabled > 0) {
-				setTimeout(enableEditors, 1000);
-			}
-		}
-
 		this.disposables.add(atom.config.onDidChange('semanticolor', function(change) {
 			if (Semanticolor.deactivated) return;
 			_.debounce(function() {
@@ -401,11 +391,10 @@ let Semanticolor = {
 			let paramName = getGrammarParamNameFromGrammarName(getGrammarName(grammar));
 			if (grammars[paramName]) {
 				editor.setGrammar(grammars[paramName]);
-				return true;
 			}
-			return false;
 		}
 	},
+
 	confirmReload: function() {
 		if (this.deactivated) {
 			return;
@@ -415,6 +404,7 @@ let Semanticolor = {
 			visible: true
 		});
 	},
+
 	deactivate: function() {
 		this.deactivated = true;
 		if (this.modalPanel && typeof this.modalPanel.destroy === 'function') {


### PR DESCRIPTION
This seems to guarantee semanticolor grammar activation at start.
Fix #14.