### PR TITLE
Prevent crash on unload

### DIFF
--- a/lib/semanticolor.js
+++ b/lib/semanticolor.js
@@ -315,8 +315,12 @@ let Semanticolor = {
 		}
 
 		atom.grammars.onDidAddGrammar(function(grammar) {
-			createGrammar(grammar);
+			// Don't bother on unload
+			if (!atom.workspace) {
+				return;
+			}
 
+			createGrammar(grammar);
 			// Activate grammar on existing text editors with matching grammar
 			atom.workspace.getTextEditors()
 				.filter(editor => editor.getGrammar().name == grammar.name)


### PR DESCRIPTION
Some packages (git-plus for example) adds grammar on unload when atom.workspace is null resulting in crash. This avoids that.